### PR TITLE
Set up go linting via GitHub Actions

### DIFF
--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.43


### PR DESCRIPTION
This sets up linting to run on pushes to `main` and pull requests.

It mostly detects errors like ineffectual assignments, errors not being checked, unread parameters and things like that.

The pipeline won't run on forks, but I think I got all the obvious cases in #11.